### PR TITLE
Fix for eraser bug in firefox 

### DIFF
--- a/src/sketch.coffee
+++ b/src/sketch.coffee
@@ -216,8 +216,8 @@
       $.sketch.tools.marker.onEvent.call this, e
     draw: (action)->
       oldcomposite = @context.globalCompositeOperation
-      @context.globalCompositeOperation = "copy"
-      action.color = "rgba(0,0,0,0)"
+      @context.globalCompositeOperation = "destination-out"
+      action.color = "rgba(0,0,0,1)"
       $.sketch.tools.marker.draw.call this, action
       @context.globalCompositeOperation = oldcomposite
 )(jQuery)


### PR DESCRIPTION
The way the eraser tool is currently implemented causes it to erase the entire sketch in firefox. This is a simple fix which will make the eraser work the same way it does in chrome. 

see: http://stackoverflow.com/questions/3328906/erasing-in-html5-canvas

"Note that firefox 3.6/4.0 implement 'copy' by erasing the entire background first. The w3c docs aren't clear as to what should happen here. Chrome (webkit?) interprets the specs as 'only where pixels are actually drawn', for example the result of a stroke()."
