### PR TITLE
#23 - Fix when using sketch.js on mobile devices

### DIFF
--- a/src/sketch.coffee
+++ b/src/sketch.coffee
@@ -119,6 +119,8 @@
     # *Internal method.* Called when a mouse or touch event is triggered 
     # that begins a paint stroke. 
     startPainting: ->
+      if @painting
+        @stopPainting()
       @painting = true
       @action = {
         tool: @tool


### PR DESCRIPTION
Fix when using sketch.js on mobile devices, due to the touchend/touchcancel events never get fired.

I did this on my end, directly on javascript and it works. I believe these changes are the coffeescript equivalent.
I did not test nor compile the project though.

This also fixes issue #19.
