### PR TITLE
Fix the demo gh-pages when accessed through https.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     <title>Sketch.js - Simple Canvas-based Drawing for jQuery</title>
-    <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script src="//code.jquery.com/jquery-latest.js"></script>
     <script src='lib/sketch.js'></script>
-    <link href='http://fonts.googleapis.com/css?family=Yellowtail|Open+Sans:400italic,700italic,400,700' rel='stylesheet' type='text/css'/>
+    <link href='//fonts.googleapis.com/css?family=Yellowtail|Open+Sans:400italic,700italic,400,700' rel='stylesheet' type='text/css'/>
 
     <style type='text/css'>
       body { font-family: "Open Sans", sans-serif; color: #444; }
@@ -116,7 +116,7 @@
             <a href='#tools_sketch' data-tool='marker'>Marker</a>
             <a href='#tools_sketch' data-tool='eraser'>Eraser</a>
           </div>
-          <canvas id='tools_sketch' width='800' height='300' style='background: url(http://farm1.static.flickr.com/91/239595759_3c3626b24a_b.jpg) no-repeat center center;'></canvas>
+          <canvas id='tools_sketch' width='800' height='300' style='background: url(//farm1.static.flickr.com/91/239595759_3c3626b24a_b.jpg) no-repeat center center;'></canvas>
           <script type='text/javascript'>
             $(function() {
               $('#tools_sketch').sketch({defaultColor: "#ff0"});


### PR DESCRIPTION
Replaced http with protocol agnostic url for https://github.io pages.

Here you can see the two sites and the differences in each.

https://intridea.github.io/sketch.js/

https://ehlovader.github.io/sketch.js/
