### PR TITLE
Eventing added to sketch.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
         source code</a>.</p>
       </article>
 
+
       <article class='example'>
         <h1>Simple Example</h1>
         
@@ -123,6 +124,29 @@
             });
           </script>
         </div>
+      </article>
+
+      <article class='info'>
+        <h1>Events</h1>
+
+        <p>Sketch.js emits custom events that can be used to coordinate other code.  
+        <ul>
+          <li>'stroke-start' signals the beginning of an action.  The action object is carried
+            as extra data.</li>
+          <li>'stroke-end' signals the end of an action.  The action object is carried
+            as extra data.</li>
+          <li>'stroke-extend' signals an additional point was added to the current action.  The point is carried
+            as extra data.</li>
+        </ul></p>
+        <p>Sketch.js also listens for two custome that can be used to manipulate the drawing from outside code.  
+        <ul>
+          <li>'clear' clears the canvas and the Sketch object of all actions. There is no extra data.</li>
+          <li>'load' adds a list of actions to the Sketch object and redraws them to the canvas.</li>
+        </ul></p>
+        <p>All of these events are triggered on the canvas itself, in the DOM.</p>        
+        <p>An example of using the 'load' trigger. Wrap actions array in another array.<br>
+        `$('#sketch').trigger('load', [actions]);`
+        </p>
       </article>
 
       <article class='info'>

--- a/lib/sketch.js
+++ b/lib/sketch.js
@@ -1,9 +1,10 @@
-var __slice = Array.prototype.slice;
+var slice = [].slice;
+
 (function($) {
   var Sketch;
   $.fn.sketch = function() {
     var args, key, sketch;
-    key = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
+    key = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
     if (this.length > 1) {
       $.error('Sketch.js can only be called on one element at a time.');
     }
@@ -43,17 +44,19 @@ var __slice = Array.prototype.slice;
       this.size = this.options.defaultSize;
       this.tool = this.options.defaultTool;
       this.actions = [];
-      this.action = [];
+      this.action = null;
       this.canvas.bind('click mousedown mouseup mousemove mouseleave mouseout touchstart touchmove touchend touchcancel', this.onEvent);
+      this.canvas.bind('load', this.onLoad);
+      this.canvas.bind('clear', this.onClear);
       if (this.options.toolLinks) {
         $('body').delegate("a[href=\"#" + (this.canvas.attr('id')) + "\"]", 'click', function(e) {
-          var $canvas, $this, key, sketch, _i, _len, _ref;
+          var $canvas, $this, i, key, len, ref, sketch;
           $this = $(this);
           $canvas = $($this.attr('href'));
           sketch = $canvas.data('sketch');
-          _ref = ['color', 'size', 'tool'];
-          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-            key = _ref[_i];
+          ref = ['color', 'size', 'tool'];
+          for (i = 0, len = ref.length; i < len; i++) {
+            key = ref[i];
             if ($this.attr("data-" + key)) {
               sketch.set(key, $(this).attr("data-" + key));
             }
@@ -65,6 +68,7 @@ var __slice = Array.prototype.slice;
         });
       }
     }
+
     Sketch.prototype.download = function(format) {
       var mime;
       format || (format = "png");
@@ -74,10 +78,12 @@ var __slice = Array.prototype.slice;
       mime = "image/" + format;
       return window.open(this.el.toDataURL(mime));
     };
+
     Sketch.prototype.set = function(key, value) {
       this[key] = value;
       return this.canvas.trigger("sketch.change" + key, value);
     };
+
     Sketch.prototype.startPainting = function() {
       this.painting = true;
       return this.action = {
@@ -87,6 +93,7 @@ var __slice = Array.prototype.slice;
         events: []
       };
     };
+
     Sketch.prototype.stopPainting = function() {
       if (this.action) {
         this.actions.push(this.action);
@@ -95,6 +102,7 @@ var __slice = Array.prototype.slice;
       this.action = null;
       return this.redraw();
     };
+
     Sketch.prototype.onEvent = function(e) {
       if (e.originalEvent && e.originalEvent.targetTouches) {
         e.pageX = e.originalEvent.targetTouches[0].pageX;
@@ -104,6 +112,25 @@ var __slice = Array.prototype.slice;
       e.preventDefault();
       return false;
     };
+
+    Sketch.prototype.onLoad = function(e, actions) {
+      var sketch;
+      sketch = $(this).data('sketch');
+      sketch.actions = sketch.actions.concat(actions);
+      sketch.redraw();
+      e.preventDefault();
+      return false;
+    };
+
+    Sketch.prototype.onClear = function(e) {
+      var sketch;
+      sketch = $(this).data('sketch');
+      sketch.actions = [];
+      sketch.redraw();
+      e.preventDefault();
+      return false;
+    };
+
     Sketch.prototype.redraw = function() {
       var sketch;
       this.el.width = this.canvas.width();
@@ -118,43 +145,52 @@ var __slice = Array.prototype.slice;
         return $.sketch.tools[this.action.tool].draw.call(sketch, this.action);
       }
     };
+
     return Sketch;
+
   })();
   $.sketch = {
     tools: {}
   };
   $.sketch.tools.marker = {
     onEvent: function(e) {
+      var itm;
       switch (e.type) {
         case 'mousedown':
         case 'touchstart':
           this.startPainting();
+          this.canvas.trigger("stroke-start", this.action);
           break;
         case 'mouseup':
         case 'mouseout':
         case 'mouseleave':
         case 'touchend':
         case 'touchcancel':
+          if (this.action) {
+            this.canvas.trigger("stroke-end", this.action);
+          }
           this.stopPainting();
       }
       if (this.painting) {
-        this.action.events.push({
+        itm = {
           x: e.pageX - this.canvas.offset().left,
           y: e.pageY - this.canvas.offset().top,
           event: e.type
-        });
+        };
+        this.action.events.push(itm);
+        this.canvas.trigger("stroke-extend", itm);
         return this.redraw();
       }
     },
     draw: function(action) {
-      var event, previous, _i, _len, _ref;
+      var event, i, len, previous, ref;
       this.context.lineJoin = "round";
       this.context.lineCap = "round";
       this.context.beginPath();
       this.context.moveTo(action.events[0].x, action.events[0].y);
-      _ref = action.events;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        event = _ref[_i];
+      ref = action.events;
+      for (i = 0, len = ref.length; i < len; i++) {
+        event = ref[i];
         this.context.lineTo(event.x, event.y);
         previous = event;
       }
@@ -170,8 +206,8 @@ var __slice = Array.prototype.slice;
     draw: function(action) {
       var oldcomposite;
       oldcomposite = this.context.globalCompositeOperation;
-      this.context.globalCompositeOperation = "copy";
-      action.color = "rgba(0,0,0,0)";
+      this.context.globalCompositeOperation = "destination-out";
+      action.color = "rgba(0,0,0,1)";
       $.sketch.tools.marker.draw.call(this, action);
       return this.context.globalCompositeOperation = oldcomposite;
     }


### PR DESCRIPTION
I have enjoyed using your thoughtfully designed library, sketch.js, for a shared whiteboard 'toy' app.  In the process of integrating sketch into my app, I found it necessary to add some eventing.   Perhaps other users of the library would benefit from these enhancements.

I added three event emits, to announce the beginning, end, and extension of each action.  Each event carries, as extra data, the action data.   I also added two event listeners, one 'clear', to clear the Sketch object and canvas, and 'load', to add a set of actions to the Sketch object and canvas.

The sketch.coffee file has been modified with the changes, and sketch.js compiled with the online compiler at coffeescript.org.   I also added a paragraph to the 'index.html' documentation file, but did not preview it.   

I do not have front-end tooling setup to compile and minify the coffeescript, so only updated the coffee file and the un-minified JavaScript.   When you merge, you might want to download merged source and run your front-end tooling scripts to finish up.

Anyway, thank you for your work.

David
